### PR TITLE
Add script to export magazine data to DOCX

### DIFF
--- a/export_to_docx.py
+++ b/export_to_docx.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-export_to_docx.py – Gera arquivo DOCX com os artigos aprovados da Revista Ateísta.
+export_to_docx.py – Gera arquivo DOCX com os artigos aprovados da Revista Ateísta,
+incluindo nome, foto e bio do autor.
 
 Uso:
     python export_to_docx.py --data-dir dados/ --out-file revista.docx
@@ -11,11 +12,14 @@ from __future__ import annotations
 
 import argparse
 import ast
+import io
 from pathlib import Path
 from typing import Any
+from urllib.request import urlopen
 
 import pandas as pd
 from docx import Document
+from docx.shared import Inches
 import bbcode
 import bleach
 
@@ -46,14 +50,31 @@ def latest_csv(folder: Path, prefix: str) -> Path:
     """Retorna o CSV mais recente com determinado prefixo."""
     return sorted(folder.glob(f"{prefix}_*.csv"))[-1]
 
+
+def fetch_image(url: str) -> bytes | None:
+    """Baixa imagem de URL e retorna bytes."""
+    if not url:
+        return None
+    try:
+        with urlopen(url) as resp:
+            return resp.read()
+    except Exception:
+        return None
+
 def build_docx(articles: list[dict], edition: dict, out_file: Path) -> None:
     """Monta o documento DOCX com título da edição e artigos."""
     doc = Document()
     doc.add_heading(edition.get("titulo") or f"Edição nº {edition.get('numero', '')}", 0)
     for art in articles:
         doc.add_heading(art.get("titulo", "Sem título"), level=1)
+        if art.get("autor_foto"):
+            img_bytes = fetch_image(art["autor_foto"])
+            if img_bytes:
+                doc.add_picture(io.BytesIO(img_bytes), width=Inches(1.5))
         if art.get("autor_nome"):
             doc.add_paragraph(art["autor_nome"])
+        if art.get("autor_bio"):
+            doc.add_paragraph(art["autor_bio"])
         doc.add_paragraph(bb2text(art.get("conteudo")))
     doc.save(out_file)
 

--- a/export_to_docx.py
+++ b/export_to_docx.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+export_to_docx.py – Gera arquivo DOCX com os artigos aprovados da Revista Ateísta.
+
+Uso:
+    python export_to_docx.py --data-dir dados/ --out-file revista.docx
+
+Requer: pandas, python-docx, bbcode, bleach.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from docx import Document
+import bbcode
+import bleach
+
+BB = bbcode.Parser()
+
+def bb2text(txt: str) -> str:
+    """Converte BBCode básico em texto simples."""
+    html = BB.format(txt or "")
+    html = html.replace("<br>", "\n").replace("<br/>", "\n").replace("<br />", "\n")
+    return bleach.clean(html, tags=[], strip=True)
+
+def clean_id(v: Any) -> str | None:
+    """Normaliza IDs que podem vir como lista, string ou objeto."""
+    if v is None:
+        return None
+    if isinstance(v, str) and v.startswith("["):
+        try:
+            lst = ast.literal_eval(v)
+            if isinstance(lst, list) and lst:
+                return clean_id(lst[0])
+        except Exception:
+            return v
+    if isinstance(v, dict):
+        return v.get("unique_id") or v.get("_id")
+    return str(v)
+
+def latest_csv(folder: Path, prefix: str) -> Path:
+    """Retorna o CSV mais recente com determinado prefixo."""
+    return sorted(folder.glob(f"{prefix}_*.csv"))[-1]
+
+def build_docx(articles: list[dict], edition: dict, out_file: Path) -> None:
+    """Monta o documento DOCX com título da edição e artigos."""
+    doc = Document()
+    doc.add_heading(edition.get("titulo") or f"Edição nº {edition.get('numero', '')}", 0)
+    for art in articles:
+        doc.add_heading(art.get("titulo", "Sem título"), level=1)
+        if art.get("autor_nome"):
+            doc.add_paragraph(art["autor_nome"])
+        doc.add_paragraph(bb2text(art.get("conteudo")))
+    doc.save(out_file)
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Exporta artigos em DOCX")
+    ap.add_argument("--data-dir", type=Path, required=True, help="Diretório com CSVs")
+    ap.add_argument("--out-file", type=Path, default=Path("revista_ateista.docx"))
+    args = ap.parse_args()
+
+    ed_df = pd.read_csv(latest_csv(args.data_dir, "edicoes"))
+    art_df = pd.read_csv(latest_csv(args.data_dir, "artigos_enriched"))
+
+    latest_num = ed_df["numero"].max()
+    edition = ed_df[ed_df["numero"] == latest_num].iloc[0].to_dict()
+    ed_id = edition["_id"]
+
+    mask = (art_df["status"] == "Aprovado") & (art_df["edicao"].apply(clean_id) == ed_id)
+    articles = art_df[mask].to_dict(orient="records")
+
+    build_docx(articles, edition, args.out_file)
+    print("✅ DOCX gerado:", args.out_file)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `export_to_docx.py` for creating a DOCX file with approved articles of the latest edition

## Testing
- `python export_to_docx.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install python-docx` *(fails: Could not find a version that satisfies the requirement python-docx)*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68913b47aacc833089a7572c76a0271f